### PR TITLE
Add continuous build with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+sudo: require
+
+language: cpp
+compiler: gcc
+
+install:
+- sudo apt-get install qt5-default qtdeclarative5-dev
+
+script:
+- qmake
+- make
+
+# branches whitelist
+branches:
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 BluetoothPairingAPP
 ===================
 
+[![Build Status](https://travis-ci.org/GENIVI/BluetoothPairingAPP.svg?branch=master)](https://travis-ci.org/GENIVI/BluetoothPairingAPP)
+
 Simple application for pairing bluetooth devices.
+
 Dependencies:
-* QT 5.6
-* BlueConnect (https://github.com/PelagiCore/BlueConnect)
+* Qt 5.6
+* [BlueConnect](https://github.com/PelagiCore/BlueConnect) (at runtime)


### PR DESCRIPTION
Example Travis-based build.  README build badge also added.

Each build needs to be enabled in the GENIVI account on travis-ci.org also (which I have done for this project, so it should build automatically after the .travis.yml is merged)

Update: Actually, the PR itself was built by Travis also.

